### PR TITLE
Fix typos in OIDC tutorial

### DIFF
--- a/docs/tutorials/oidc/openid-connect.mdx
+++ b/docs/tutorials/oidc/openid-connect.mdx
@@ -6,11 +6,11 @@ sidebar_position: 2
 
 Quran.Foundation's OAuth 2.0 APIs can be used for both authentication and authorization.
 
-In this [guide](/docs/tutorials/oidc/getting-started-with-oauth2), we have breifly explained what OAuth2 is and how to integrate with Quran.Foundation's OAuth2 server.
+In this [guide](/docs/tutorials/oidc/getting-started-with-oauth2), we have briefly explained what OAuth2 is and how to integrate with Quran.Foundation's OAuth2 server.
 
-Besides OAuth2, Quran.Foundation also supports [OpenId Connect](https://openid.net/connect) standards by providing the [UserInfo Endpoint](/docs/oauth2_apis_versioned/get-oidc-user-info) to get more information about the user.
+Besides OAuth2, Quran.Foundation also supports [OpenID Connect](https://openid.net/connect) standards by providing the [UserInfo Endpoint](/docs/oauth2_apis_versioned/get-oidc-user-info) to get more information about the user.
 
-To be able to access OpenId Connect's endpoints, make sure to include `openid` in the list of requested [scopes](/docs/user_related_apis_versioned/scopes). Once this is done, besides `access_token`, the authorization callback will also contain a [JWT](https://www.rfc-editor.org/rfc/rfc7519) `id_token` parameter.
+To be able to access OpenID Connect's endpoints, make sure to include `openid` in the list of requested [scopes](/docs/user_related_apis_versioned/scopes). Once this is done, besides `access_token`, the authorization callback will also contain a [JWT](https://www.rfc-editor.org/rfc/rfc7519) `id_token` parameter.
 
 The [ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) (`id_token`) contains information about the user and can be decoded using one of the JWT [libraries](https://jwt.io/libraries) to know more about the identity of the user. Below is an example of a decoded `id_token`:
 


### PR DESCRIPTION
## Summary
- fix spelling of "briefly"
- capitalize OpenID in sentences

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6bba75c832bae08699a4cb3db7e