### PR TITLE
Update README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 ### Installation
 
+This project requires **Node.js >=16.14**.
+
 ```
 $ yarn
 ```
@@ -11,18 +13,20 @@ $ yarn
 ### Local Development
 
 ```
+$ yarn gen-all
 $ yarn start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+Run `yarn gen-all` to generate the API documentation used by the site. The `yarn start` command then launches a local development server using the generated docs and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
 ```
+$ yarn gen-all
 $ yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+Run `yarn gen-all` before building to ensure the API documentation is up to date. The `yarn build` command then generates static content into the `build` directory which can be served using any static contents hosting service.
 
 ### Deployment
 


### PR DESCRIPTION
## Summary
- document Node.js version requirement
- clarify generating docs before starting/building
- show that `yarn start` uses the generated docs

## Testing
- `yarn install` *(fails: `postman-code-generators` build error)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6c8d0ec832ba97174c34700370b